### PR TITLE
x-button now throws an event

### DIFF
--- a/client/services/InputsService.lua
+++ b/client/services/InputsService.lua
@@ -1,8 +1,20 @@
 InputsService = {}
 local callbackOfCurrentOpenInput = nil
 
+---@param result string
+---@private
+InputsService._callCallbackIfNotCalledAlready = function(result)
+
+    if type(callbackOfCurrentOpenInput) ~= 'function' then
+        return
+    end
+
+    callbackOfCurrentOpenInput(result)
+    callbackOfCurrentOpenInput = nil -- Don't call callback twice
+end
+
 InputsService.CloseInput = function()
-    callbackOfCurrentOpenInput = nil
+    InputsService._callCallbackIfNotCalledAlready(nil)
     SetNuiFocus(false, false)
     SendNUIMessage(NUIEvent:New({ style = "none" }))
 end
@@ -13,7 +25,7 @@ InputsService.CallCallbackAndCloseInput = function(result)
     local resultText = result.stringtext or nil
 
     if resultText ~= nil then
-        callbackOfCurrentOpenInput(resultText)
+        InputsService._callCallbackIfNotCalledAlready(resultText)
     end
 
     Wait(1)


### PR DESCRIPTION
This is a workaround to consider if the 'x' button is pressed to close the input without an submit. The submit originally calls the callback and executes the InputsService.CloseInput() method after that. The 'x' button calls the InputsService.CloseInput() directly. So we need to check if the callback was already called by the submit otherwise the trigger was the 'x' button then we need to call the callback now.